### PR TITLE
Add NoCache option

### DIFF
--- a/src/main/groovy/com/ullink/NuGetRestore.groovy
+++ b/src/main/groovy/com/ullink/NuGetRestore.groovy
@@ -7,6 +7,7 @@ class NuGetRestore extends BaseNuGet {
     def solutionFile
     def source
     def configFile
+    def nocache = false
 
     NuGetRestore() {
         super('restore')
@@ -41,6 +42,9 @@ class NuGetRestore extends BaseNuGet {
         }
         if (solutionFile) {
             commandLineArgs += solutionFile
+        }
+        if (nocache) {
+            commandLineArgs += "-NoCache"
         }
 
         return commandLineArgs


### PR DESCRIPTION
If a nuget package is re-released for some reason, this option prevents
nuget from using a cache in AppData and avoid retrieving the old one.
For instance, we re-release snapshots packages at each gerrit patchset.