### PR TITLE
Fix clean use together with other tasks

### DIFF
--- a/src/main/groovy/com/ullink/BaseNuGet.groovy
+++ b/src/main/groovy/com/ullink/BaseNuGet.groovy
@@ -12,11 +12,6 @@ public class BaseNuGet extends Exec {
 
     public BaseNuGet() {
         localNuget = new File(getNugetHome(), NUGET_EXE)
-        if (!localNuget.exists()) {
-            new URL('https://nuget.org/nuget.exe').withInputStream { i ->
-                localNuget.withOutputStream{ it << i }
-            }
-        }
     }
 
     private File getNugetHome(){
@@ -40,6 +35,11 @@ public class BaseNuGet extends Exec {
 
     @Override
     void exec() {
+        if (!localNuget.exists()) {
+            new URL('https://nuget.org/nuget.exe').withInputStream { i ->
+                localNuget.withOutputStream{ it << i }
+            }
+        }
         if (isFamily(FAMILY_WINDOWS)) {
             executable localNuget
         } else {

--- a/src/main/groovy/com/ullink/BaseNuGet.groovy
+++ b/src/main/groovy/com/ullink/BaseNuGet.groovy
@@ -6,12 +6,10 @@ import static org.apache.tools.ant.taskdefs.condition.Os.*
 
 public class BaseNuGet extends Exec {
     private static final String NUGET_EXE = 'NuGet.exe'
-    protected File localNuget
-    
+
     String verbosity
 
     public BaseNuGet() {
-        localNuget = new File(getNugetHome(), NUGET_EXE)
     }
 
     private File getNugetHome(){
@@ -35,6 +33,7 @@ public class BaseNuGet extends Exec {
 
     @Override
     void exec() {
+        def localNuget = new File(getNugetHome(), NUGET_EXE)
         if (!localNuget.exists()) {
             new URL('https://nuget.org/nuget.exe').withInputStream { i ->
                 localNuget.withOutputStream{ it << i }

--- a/src/test/groovy/com/ullink/NuGetPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetPluginTest.groovy
@@ -32,6 +32,15 @@ class NuGetPluginTest {
     }
 
     @Test
+    public void nugetWithCleanWorks() {
+        project.task('nuget', type: BaseNuGet) {
+            args 'help'
+        }
+        project.tasks.clean.execute()
+        project.tasks.nuget.execute()
+    }
+
+    @Test
     public void nugetPackGenerateNuspec() {
         project.nugetPack {
             nuspec {


### PR DESCRIPTION
Downloading NuGet.exe in the ctor was too early if clean task was
 used in the task graph as well.
Delayed it to the execution part.