### PR TITLE
Adding version override.

### DIFF
--- a/src/main/groovy/com/ullink/NuGetPack.groovy
+++ b/src/main/groovy/com/ullink/NuGetPack.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.OutputFile;
 
 class NuGetPack extends BaseNuGet {
 
+    def packageVersion
     def nuspecFile
     Closure nuspec
     def csprojPath
@@ -51,8 +52,7 @@ class NuGetPack extends BaseNuGet {
         args '-OutputDirectory', destDir
 
         if (basePath) args '-BasePath', basePath
-
-        def version = spec.metadata.version ?: project.version
+        def version = packageVersion ?: spec.metadata.version ?: project.version
         if (version) args '-Version', version
 
         if (exclude) args '-Exclude', exclude


### PR DESCRIPTION
I need the ability to override the version to be different than either the project or nuspec version. This allows me to use a custom version which allows us to programmatically create snapshot versions before release.