### PR TITLE
Extract task nugetSpec from nugetPack to generate nuspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,6 @@ Plugin changelog
 -------
 
 * nugetPush input package now defaults to nugetPack generated one (if any)
-* nugetPack now defaults id, version and description in nuspec generation
+* nuspec generation now defaults id, version and description in nuspec generation
+* extract task nugetSpec from nugetPack to generate nuspec
+* support Map for defining nuspec in nugetSpec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ Plugin changelog
 -------
 
 * nugetPush input package now defaults to nugetPack generated one (if any)
+* nugetPack now defaults id, version and description in nuspec generation

--- a/README.md
+++ b/README.md
@@ -23,22 +23,22 @@ Sample usage:
     apply plugin:'nuget'
 
     nugetPack {
-    	// this Closure will be applied to the nuspec XMLBuilder
-		nuspec {
-			metadata() {
-				id archivesBaseName
-				delegate.version version
-				title 'project title'
-				authors 'Francois Valdy'
-				delegate.description '''some looong description...'''
-				// ...
-			}
-			delegate.files() {
-				delegate.file(src: 'somefile', target: 'tools')
-			}
-		}
+        // this Closure will be applied to the nuspec XMLBuilder
+        nuspec {
+            metadata() {
+                title 'project title'
+                authors 'Francois Valdy'
+                // id archivesBaseName,      default is project.name
+                // delegate.version version, default is project.version
+                // delegate.description '''some looong description...''', default is project.description
+                // ...
+            }
+            delegate.files() {
+                delegate.file(src: 'somefile', target: 'tools')
+            }
+        }
     }
-	
+
 ## nugetRestore
 
     Nuget restore is used to retrieve missing packages before starting the build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ It also supports pack & push commands through built-in tasks, nugetPack, nugetPu
 You can see this plugin being used for real on [il-repack](https://github.com/gluck/il-repack) project.
 (together with msbuild one)
 
-Sample usage:
+## nugetSpec
+
+    The task is to generate nuspec file by custom configuration
+
+    - Sample usage:
 
     buildscript {
         repositories {
@@ -22,21 +26,22 @@ Sample usage:
     
     apply plugin:'nuget'
 
-    nugetPack {
-        // this Closure will be applied to the nuspec XMLBuilder
-        nuspec {
-            metadata() {
-                title 'project title'
-                authors 'Francois Valdy'
-                // id archivesBaseName,      default is project.name
-                // delegate.version version, default is project.version
-                // delegate.description '''some looong description...''', default is project.description
+    nugetSpec {
+        // Closure will be applied to XMLBuilder
+        nuspec = [
+            metadata: [
+                title:          'project title'
+                authors:        'Francois Valdy'
+                // id:          default is project.name
+                // version:     default is project.version
+                // description: default is project.description
                 // ...
-            }
-            delegate.files() {
-                delegate.file(src: 'somefile', target: 'tools')
-            }
-        }
+            ]
+            files: [
+                { file (src: 'somefile1', target: 'tools') }
+                { file (src: 'somefile2', target: 'tools') }
+            ]
+        ]
     }
 
 ## nugetRestore

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can see this plugin being used for real on [il-repack](https://github.com/gl
     apply plugin:'nuget'
 
     nugetSpec {
-        // Closure will be applied to XMLBuilder
+        // Array, Map and Closure could be used to generate nuspec XML, for details please check NuGetSpecTest 
         nuspec = [
             metadata: [
                 title:          'project title'

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can see this plugin being used for real on [il-repack](https://github.com/gl
                 // ...
             ]
             files: [
-                { file (src: 'somefile1', target: 'tools') }
+                { file (src: 'somefile1', target: 'tools') },
                 { file (src: 'somefile2', target: 'tools') }
             ]
         ]

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ description 'Gradle plugin for NuGet, to package, upload artifacts and restore p
 
 dependencies {
     testCompile 'junit:junit:4.11'
+    testCompile 'xmlunit:xmlunit:1.6'
 }
 
 bintray {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip

--- a/src/main/groovy/com/ullink/NuGetPack.groovy
+++ b/src/main/groovy/com/ullink/NuGetPack.groovy
@@ -118,7 +118,7 @@ class NuGetPack extends BaseNuGet {
         builder.bind {
             'package' (xmlns: 'http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd') {
                 if (nuspecCustom) {
-                    nuspecCustom.resolveStrategy = DELEGATE_ONLY
+                    nuspecCustom.resolveStrategy = DELEGATE_FIRST
                     nuspecCustom.delegate = delegate
                     nuspecCustom.call()
                 }

--- a/src/main/groovy/com/ullink/NuGetPlugin.groovy
+++ b/src/main/groovy/com/ullink/NuGetPlugin.groovy
@@ -7,17 +7,24 @@ import org.gradle.api.plugins.BasePlugin
 class NuGetPlugin implements Plugin<Project> {
     void apply(Project project) {
         project.apply plugin: 'base'
-        def nuget = project.task('nugetPack', type: NuGetPack)
-        nuget.group = BasePlugin.BUILD_GROUP
-        nuget.description = 'Executes nuget pack command.'
 
-        nuget = project.task('nugetPush', type: NuGetPush)
-        nuget.group = BasePlugin.UPLOAD_GROUP
-        nuget.description = 'Executes nuget push command.'
-
-        nuget = project.task('nugetRestore', type: NuGetRestore)
+        def nuget = project.task('nugetRestore', type: NuGetRestore)
         nuget.group = BasePlugin.BUILD_GROUP
         nuget.description = 'Executes nuget package restore command.'
+
+        def nugetSpec = project.task('nugetSpec', type: NuGetSpec)
+        nugetSpec.group = BasePlugin.BUILD_GROUP
+        nugetSpec.description = 'Generates nuspec file.'
+
+        def nugetPack = project.task('nugetPack', type: NuGetPack)
+        nugetPack.group = BasePlugin.BUILD_GROUP
+        nugetPack.description = 'Executes nuget pack command.'
+        nugetPack.dependsOn nugetSpec
+
+        def nugetPush = project.task('nugetPush', type: NuGetPush)
+        nugetPush.group = BasePlugin.UPLOAD_GROUP
+        nugetPush.description = 'Executes nuget push command.'
+        nugetPush.dependsOn nugetPack
     }
 }
 

--- a/src/main/groovy/com/ullink/NuGetPush.groovy
+++ b/src/main/groovy/com/ullink/NuGetPush.groovy
@@ -14,11 +14,11 @@ class NuGetPush extends BaseNuGet {
     }
 
     String getNugetPackOutputFile() {
-        if (dependentNugetSpec)
-           dependentNugetSpec.packageFile
+        if (dependentNuGetPack)
+           dependentNuGetPack.packageFile
     }
 
-    NuGetPack getDependentNugetSpec() {
+    NuGetPack getDependentNuGetPack() {
         dependsOn.find { it instanceof NuGetPack }
     }
 

--- a/src/main/groovy/com/ullink/NuGetPush.groovy
+++ b/src/main/groovy/com/ullink/NuGetPush.groovy
@@ -14,9 +14,12 @@ class NuGetPush extends BaseNuGet {
     }
 
     String getNugetPackOutputFile() {
-        def tasks = project.tasks.withType(NuGetPack.class)
-        if (tasks.size() == 1)
-           tasks.first().packageFile
+        if (dependentNugetSpec)
+           dependentNugetSpec.packageFile
+    }
+
+    NuGetPack getDependentNugetSpec() {
+        dependsOn.find { it instanceof NuGetPack }
     }
 
     @Override

--- a/src/main/groovy/com/ullink/NuGetPush.groovy
+++ b/src/main/groovy/com/ullink/NuGetPush.groovy
@@ -11,19 +11,17 @@ class NuGetPush extends BaseNuGet {
 
     NuGetPush() {
         super('push')
-        conventionMapping.map "nupkgFile", { project.tasks.nugetPack.packageFile }
-        project.afterEvaluate {
-            if (nupkgFile) {
-                def tasks = project.tasks.withType(NuGetPack.class).findAll { it.packageFile == nupkgFile }
-                if (tasks.size() == 1)
-                    dependsOn tasks[0]
-            }
-        }
+    }
+
+    String getNugetPackOutputFile() {
+        def tasks = project.tasks.withType(NuGetPack.class)
+        if (tasks.size() == 1)
+           tasks.first().packageFile
     }
 
     @Override
     void exec() {
-        args getNupkgFile()
+        args nupkgFile ?: nugetPackOutputFile
 
         if (serverUrl) args '-Source', serverUrl
         if (apiKey) args '-ApiKey', apiKey

--- a/src/main/groovy/com/ullink/NuGetSpec.groovy
+++ b/src/main/groovy/com/ullink/NuGetSpec.groovy
@@ -1,0 +1,87 @@
+package com.ullink
+
+import groovy.util.XmlSlurper
+import groovy.util.slurpersupport.GPathResult
+import groovy.xml.XmlUtil
+import groovy.xml.MarkupBuilder
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.Exec
+
+class NuGetSpec extends Exec {
+
+    def nuspecFile
+    def nuspec
+
+    void exec() {
+        generateNuspecFile()
+    }
+
+    File getTempNuspecFile() {
+        new File(temporaryDir, project.name + '.nuspec')
+    }
+
+    File getNuspecFile() {
+        nuspecFile ?: getTempNuspecFile()
+    }
+
+    void generateNuspecFile() {
+        def nuspecXml = generateNuspec()
+        if (nuspecXml) {
+            def file = getNuspecFile()
+            file.write nuspecXml
+        }
+    }
+
+    String generateNuspec() {
+        if (nuspec) {
+            def sw = new StringWriter()
+            new groovy.xml.MarkupBuilder(sw).with {
+                def visitor
+                visitor = { entry ->
+                    switch (entry) {
+                        case { entry instanceof Closure }:
+                            entry.resolveStrategy = DELEGATE_FIRST
+                            entry.delegate = delegate
+                            entry.call()
+                            break
+                        case { entry instanceof Map.Entry }:
+                            "$entry.key" { visitor entry.value }
+                            break
+                        case { entry instanceof Map || entry instanceof Collection }:
+                            entry.collect(visitor)
+                            break
+                        default:
+                            mkp.yield(entry)
+                            break
+                    }
+                }
+                'package' (xmlns: 'http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd') {
+                    visitor nuspec
+                }
+            }
+            supplementDefaultValueOnNuspec sw.toString()
+        }
+    }
+
+    String supplementDefaultValueOnNuspec(String nuspecString) {
+
+        def root = new XmlSlurper(false, false).parseText(nuspecString)
+
+        def defaultValues = {}
+        def applyDefaultValue = { String node, String value ->
+            if (root.metadata[node].isEmpty()) {
+                defaultValues <<= { delegate."$node" value }
+            }
+        }
+        applyDefaultValue ('id', project.name)
+        applyDefaultValue ('version', project.version)
+        applyDefaultValue ('description', project.description)
+
+        if (root.metadata.isEmpty()) {
+            root.appendNode { metadata defaultValues }
+        } else {
+            root.metadata.appendNode defaultValues
+        }
+        XmlUtil.serialize (root)
+    }
+}

--- a/src/test/groovy/com/ullink/NuGetPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetPluginTest.groovy
@@ -21,52 +21,36 @@ class NuGetPluginTest {
     public void nugetPluginAddsNuGetTasksToProject() {
         assertTrue(project.tasks.nugetPack instanceof NuGetPack)
         assertTrue(project.tasks.nugetPush instanceof NuGetPush)
-    }
-
-    @Test
-    public void nugetPackGenerateNuspec() {
-        project.version = '2.1'
-        project.description = 'baz'
-        project.nugetPack {
-            nuspec {
-                metadata() {
-                    id 'foo'
-                    delegate.description 'bar'
-                }
-            }
-        }
-        project.tasks.nugetPack.generateNuspecFile()
-        assertEquals (
-'''<?xml version="1.0" encoding="UTF-8"?><package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-  <metadata>
-    <id>foo</id>
-    <description>bar</description>
-    <version>2.1</version>
-  </metadata>
-</package>'''.replaceAll("[\r\n]", ""), project.tasks.nugetPack.getNuSpecFile().text.replaceAll("[\r\n]", "").trim())
+        assertTrue(project.tasks.nugetSpec instanceof NuGetSpec)
     }
 
     @Test
     public void nugetPackWorks() {
+
+        project.tasks.clean.execute()
+
+        File nuspec = new File(project.tasks.nugetPack.temporaryDir, 'foo.nuspec')
+        nuspec.text = '''<?xml version='1.0'?>
+<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
+  <metadata>
+    <id>foo</id>
+    <authors>Nobody</authors>
+    <version>1.2.3</version>
+    <description>sss</description>
+  </metadata>
+  <files>
+    <file src='foo.txt' />
+  </files>
+</package>'''
+
+        File fooFile = new File(project.tasks.nugetPack.temporaryDir, 'foo.txt')
+        fooFile.text = "Bar"
+
         project.nugetPack {
             basePath = project.tasks.nugetPack.temporaryDir
-            nuspec {
-                metadata() {
-                    id 'empty-package'
-                    version '1.2.3'
-                    authors 'Nobody'
-                    delegate.description('Here to assert nugetPack works')
-                    language 'en-US'
-                    projectUrl 'https://github.com/Ullink/gradle-nuget-plugin'
-                }
-                files() {
-                    file(src: 'foo.txt')
-                }
-            }
+            nuspecFile = nuspec
         }
-        project.tasks.clean.execute()
-        File fooFile = new File(project.tasks.nugetPack.temporaryDir, 'foo.txt');
-        fooFile.text = "Bar";
+
         project.tasks.nugetPack.execute()
         assertTrue(project.tasks.nugetPack.packageFile.exists())
     }

--- a/src/test/groovy/com/ullink/NuGetPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetPluginTest.groovy
@@ -26,12 +26,12 @@ class NuGetPluginTest {
     @Test
     public void nugetPackGenerateNuspec() {
         project.version = '2.1'
-        project.description = 'project description'
+        project.description = 'baz'
         project.nugetPack {
             nuspec {
                 metadata() {
-                    id 'bar'
-                    delegate.description 'real project description'
+                    id 'foo'
+                    delegate.description 'bar'
                 }
             }
         }
@@ -39,8 +39,8 @@ class NuGetPluginTest {
         assertEquals (
 '''<?xml version="1.0" encoding="UTF-8"?><package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>bar</id>
-    <description>real project description</description>
+    <id>foo</id>
+    <description>bar</description>
     <version>2.1</version>
   </metadata>
 </package>'''.replaceAll("[\r\n]", ""), project.tasks.nugetPack.getNuSpecFile().text.replaceAll("[\r\n]", "").trim())

--- a/src/test/groovy/com/ullink/NuGetPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetPluginTest.groovy
@@ -25,14 +25,25 @@ class NuGetPluginTest {
 
     @Test
     public void nugetPackGenerateNuspec() {
+        project.version = '2.1'
+        project.description = 'project description'
         project.nugetPack {
             nuspec {
                 metadata() {
-                    id 'foo'
+                    id 'bar'
+                    delegate.description 'real project description'
                 }
             }
         }
         project.tasks.nugetPack.generateNuspecFile()
+        assertEquals (
+'''<?xml version="1.0" encoding="UTF-8"?><package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>bar</id>
+    <description>real project description</description>
+    <version>2.1</version>
+  </metadata>
+</package>'''.replaceAll("[\r\n]", ""), project.tasks.nugetPack.getNuSpecFile().text.replaceAll("[\r\n]", "").trim())
     }
 
     @Test

--- a/src/test/groovy/com/ullink/NuGetPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetPluginTest.groovy
@@ -36,7 +36,7 @@ class NuGetPluginTest {
     <id>foo</id>
     <authors>Nobody</authors>
     <version>1.2.3</version>
-    <description>sss</description>
+    <description>fooDescription</description>
   </metadata>
   <files>
     <file src='foo.txt' />

--- a/src/test/groovy/com/ullink/NuGetSpecTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetSpecTest.groovy
@@ -69,7 +69,7 @@ class NuGetSpecTest {
                     }
                 ],
                 files: [
-                    { file ( src: 'bar', target: 'barTarget' ) }
+                    { file ( src: 'bar', target: 'barTarget' ) },
                     { file ( src: 'baz', target: 'bazTarget' ) }
                 ]
             ]

--- a/src/test/groovy/com/ullink/NuGetSpecTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetSpecTest.groovy
@@ -1,0 +1,151 @@
+package com.ullink
+
+import org.junit.Before
+
+import static org.junit.Assert.*
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import org.custommonkey.xmlunit.XMLUnit
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual
+
+class NuGetSpecTest {
+
+    private Project project
+
+    @Before
+    public void init() {
+        XMLUnit.setIgnoreWhitespace(true)
+        project = ProjectBuilder.builder().build()
+        project.apply plugin: 'nuget'
+    }
+
+    @Test
+    public void generateNuspec_Closure() {
+        project.nugetSpec {
+            nuspec {
+                metadata {
+                    id 'foo'
+                    delegate.description 'fooDescription'
+                    frameworkAssemblies {
+                        frameworkAssembly (assemblyName: "System.Web", targetFramework: "net40")
+                    }
+                }
+                files {
+                    file ( src: 'bar', target: 'barTarget' )
+                    file ( src: 'baz', target: 'bazTarget' )
+                }
+            }
+        }
+        def expected =
+        '''
+        <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+            <metadata>
+                <id>foo</id>
+                <version>unspecified</version>
+                <description>fooDescription</description>
+                <frameworkAssemblies>
+                    <frameworkAssembly assemblyName='System.Web' targetFramework='net40' />
+                </frameworkAssemblies>
+            </metadata>
+            <files>
+                <file src='bar' target='barTarget' />
+                <file src='baz' target='bazTarget' />
+            </files>
+        </package>'''
+
+        assertXMLEqual (expected, project.tasks.nugetSpec.generateNuspec())
+    }
+
+    @Test
+    public void generateNuspec_Map() {
+        project.nugetSpec {
+            nuspec = [
+                metadata: [
+                    id: 'foo',
+                    description: 'fooDescription',
+                    frameworkAssemblies: {
+                        frameworkAssembly (assemblyName: "System.Web", targetFramework: "net40")
+                    }
+                ],
+                files: [
+                    { file ( src: 'bar', target: 'barTarget' ) }
+                    { file ( src: 'baz', target: 'bazTarget' ) }
+                ]
+            ]
+        }
+        def expected =
+        '''
+        <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+            <metadata>
+                <id>foo</id>
+                <version>unspecified</version>
+                <description>fooDescription</description>
+                <frameworkAssemblies>
+                    <frameworkAssembly assemblyName='System.Web' targetFramework='net40' />
+                </frameworkAssemblies>
+            </metadata>
+            <files>
+                <file src='bar' target='barTarget' />
+                <file src='baz' target='bazTarget' />
+            </files>
+        </package>'''
+        assertXMLEqual (expected, project.tasks.nugetSpec.generateNuspec())
+    }
+
+    @Test
+    public void generateNuspec_DefaultValue() {
+        Project project = ProjectBuilder.builder().withName('foo').build()
+        project.with {
+            description = 'fooDescription'
+            version = '2.1'
+            apply plugin: 'nuget'
+        }
+
+        project.nugetSpec {
+            nuspec { }
+        }
+
+        def expected =
+        '''
+        <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+            <metadata>
+                <id>foo</id>
+                <version>2.1</version>
+                <description>fooDescription</description>
+            </metadata>
+        </package>'''
+        assertXMLEqual (expected, project.tasks.nugetSpec.generateNuspec())
+    }
+
+    @Test
+    public void generateNuspec_OverridDefaultValue() {
+        Project project = ProjectBuilder.builder().withName('foo').build()
+        project.with {
+            description = 'fooDescription'
+            version = '2.1'
+            apply plugin: 'nuget'
+        }
+
+        project.nugetSpec {
+            nuspec = [
+                metadata: [
+                    id: 'bar',
+                    description: 'barDescription',
+                    version: '4.5'
+                ]
+            ]
+        }
+
+        def expected =
+        '''
+        <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+            <metadata>
+                <id>bar</id>
+                <version>4.5</version>
+                <description>barDescription</description>
+            </metadata>
+        </package>'''
+        assertXMLEqual (expected, project.tasks.nugetSpec.generateNuspec())
+    }
+}


### PR DESCRIPTION
On top of previous pull request

- support Map for defining nuspec in nugetSpec which could allow more flexible nuspec generation like doing modification before generation
- attemp to change the way on getting output based on task dependency, to avoid depending the output in configuration phase but could be changed during execution