### PR TITLE
nuspec files from msbuild/csproj if not provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Plugin changelog
 2.11
 -------
 * handled packages with developmentDependency set to true and ignore them as a dependencies
+* title is not provided anymore ('nuget pack' take the id value if the title is not provided)
+* The default nuspec files are provided only if it's not provided by nuspec task settings
 
 2.10
 -------

--- a/src/main/groovy/com/ullink/NuGetSpec.groovy
+++ b/src/main/groovy/com/ullink/NuGetSpec.groovy
@@ -92,13 +92,15 @@ class NuGetSpec extends Exec {
         if (msbuildTaskExists) {
             def mainProject = project.msbuild.mainProject
 
-            def defaultFiles = []
-            project.msbuild.mainProject.dotnetArtifacts.each {
-                artifact ->
-                    def fwkFolderVersion = mainProject.properties.TargetFrameworkVersion.toString().replace('v', '').replace('.', '')
-                    defaultFiles.add({ file(src: artifact.toString(), target: 'lib/net' + fwkFolderVersion) })
+            if(root.files.isEmpty()) {
+                def defaultFiles = []
+                project.msbuild.mainProject.dotnetArtifacts.each {
+                    artifact ->
+                        def fwkFolderVersion = mainProject.properties.TargetFrameworkVersion.toString().replace('v', '').replace('.', '')
+                        defaultFiles.add({ file(src: artifact.toString(), target: 'lib/net' + fwkFolderVersion) })
+                }
+                appendAndCreateParentIfNeeded('files', defaultFiles)
             }
-            appendAndCreateParentIfNeeded('files', defaultFiles)
 
             def packageConfigFile = new File(
                     new File(mainProject.projectFile).parentFile,

--- a/src/test/groovy/com/ullink/NuGetSpecTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetSpecTest.groovy
@@ -182,6 +182,43 @@ class NuGetSpecTest {
     }
 
     @Test
+    public void generateNuspec_withoutDefaultFilesAsTheyAreAlreadyProvided() {
+        Project project = ProjectBuilder.builder().withName('foo').build()
+        project.with {
+            apply plugin: 'nuget'
+        }
+        def msbuildTask = new MSBuildTaskBuilder()
+                .withAssemblyName('bar')
+                .withFrameworkVersion('v3.5')
+                .withArtifact('folder/bin/bar.dll')
+                .withProjectFile('folder/does not exist')
+                .build()
+        project.tasks.add(msbuildTask)
+
+        project.nugetSpec {
+            nuspec {
+                files {
+                    file(src: 'anotherLib.dll', target: 'lib/net45')
+                }
+            }
+        }
+
+        def expected =
+                '''
+        <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+            <metadata>
+                <id>foo</id>
+                <version>unspecified</version>
+                <description>foo</description>
+            </metadata>
+            <files>
+                <file src="anotherLib.dll" target="lib/net45" />
+            </files>
+        </package>'''
+        assertXMLEqual (expected, project.tasks.nugetSpec.generateNuspec())
+    }
+
+    @Test
     public void generateNuspec_defaultDependenciesFromPackageConfig() {
         Project project = ProjectBuilder.builder().withName('foo').build()
         project.with {


### PR DESCRIPTION
If no nuspec files are already provided, it provides them using msbuild artifacts and csproj settings
Add unit tests
Update change logs