### PR TITLE
Add 'sources' parameter on NugetRestore task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Plugin changelog
 2.13
 -------
 * Fix copyright system © in nuget spec.
+* NuGetRestore task now has a 'sources' parameter just like the NugetInstall task. It enables
+multiple sources to be set.
 
 2.12
 -------

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 2.13
+version = 2.13-SNAPSHOT
 

--- a/src/main/groovy/com/ullink/NuGetInstall.groovy
+++ b/src/main/groovy/com/ullink/NuGetInstall.groovy
@@ -5,7 +5,7 @@ class NuGetInstall extends BaseNuGet {
     def packageId
     def packagesConfigFile
 
-    def sources = []
+    def sources = [] as Set
     def outputDirectory
     def version
     def includeVersionInPath = true

--- a/src/main/groovy/com/ullink/NuGetRestore.groovy
+++ b/src/main/groovy/com/ullink/NuGetRestore.groovy
@@ -5,7 +5,7 @@ class NuGetRestore extends BaseNuGet {
     def solutionFile
     def packagesConfigFile
 
-    def source
+    def sources = [] as Set
     def noCache = false
     def configFile
     def requireConsent = false
@@ -17,12 +17,20 @@ class NuGetRestore extends BaseNuGet {
         super('restore')
     }
 
+    /**
+     * Only provided for backward compatibility. Uses 'sources' instead
+     */
+    def setSource(String source) {
+        sources.clear()
+        sources.add(source)
+    }
+
     @Override
     void exec() {
         if (packagesConfigFile) args packagesConfigFile
         if (solutionFile) args solutionFile
 
-        if (source) args '-Source', source
+        if (!sources.isEmpty()) args '-Source', sources.join(';')
         if (noCache) args '-NoCache'
         if (configFile) args '-ConfigFile', configFile
         if (requireConsent) args '-RequireConsent'
@@ -31,7 +39,7 @@ class NuGetRestore extends BaseNuGet {
         if (disableParallelProcessing) args '-DisableParallelProcessing'
 
         project.logger.info "Restoring NuGet packages " +
-            (source ? "from $source" : '') +
+            (sources ? "from $sources" : '') +
             (packagesConfigFile ? "for packages.config ($packagesConfigFile)": '') +
             (solutionFile ? "for solution file ($solutionFile)" : '')
         super.exec()


### PR DESCRIPTION
The NugetInstall task was already using this logic:
since multiple sources may be specified when installing or
restoring, having a sources parameter that is based on a
set makes sense