### PR TITLE
Enable dependencies management with project.json

### DIFF
--- a/src/main/groovy/com/ullink/NuGetSpec.groovy
+++ b/src/main/groovy/com/ullink/NuGetSpec.groovy
@@ -1,5 +1,8 @@
 package com.ullink
 
+import com.ullink.packagesparser.NugetParser
+import com.ullink.packagesparser.PackagesConfigParser
+import com.ullink.packagesparser.ProjectJsonParser
 import groovy.util.slurpersupport.GPathResult
 import groovy.xml.XmlUtil
 import org.gradle.api.tasks.Exec
@@ -63,6 +66,7 @@ class NuGetSpec extends Exec {
     String supplementDefaultValueOnNuspec(String nuspecString) {
         def final msbuildTaskExists = project.tasks.findByName('msbuild') != null
         def final packageConfigFileName = 'packages.config'
+        def final projectJsonFileName = 'project.json'
 
         GPathResult root = new XmlSlurper(false, false).parseText(nuspecString)
 
@@ -102,24 +106,12 @@ class NuGetSpec extends Exec {
                 }
                 appendAndCreateParentIfNeeded('files', defaultFiles)
             }
+            def dependencies = []
+            dependencies.addAll getDependencies(mainProject, packageConfigFileName, new PackagesConfigParser())
+            dependencies.addAll getDependencies(mainProject, projectJsonFileName, new ProjectJsonParser())
 
-            def packageConfigFile = new File(
-                    new File(mainProject.projectFile).parentFile,
-                    packageConfigFileName)
-            if (packageConfigFile.exists()) {
-                project.logger.debug("Adding dependencies from packages.config")
-                def defaultDependencies = []
-                def packages = new XmlParser().parse(packageConfigFile)
-                packages.package
-                        .findAll { !it.@developmentDependency.toString().toBoolean() }
-                        .each {
-                    packageElement ->
-                        defaultDependencies.add({
-                            dependency(id: packageElement.@id, version: packageElement.@version)
-                        })
-                }
-                setDefaultMetadata('dependencies', defaultDependencies)
-            }
+            if (!dependencies.isEmpty())
+                setDefaultMetadata('dependencies', dependencies)
         }
 
         appendAndCreateParentIfNeeded('metadata', defaultMetadata)
@@ -127,5 +119,16 @@ class NuGetSpec extends Exec {
         project.logger.info("Generated NuGetSpec file with ${root.files.file.size()} files " +
                 "and ${root.dependencies.dependecy.size()} dependencies")
         XmlUtil.serialize (root)
+    }
+
+    Collection getDependencies(def mainProject, String fileName, NugetParser parser) {
+        def file = new File(
+                new File(mainProject.projectFile).parentFile,
+                fileName)
+        if (file.exists()) {
+            project.logger.debug("Adding dependencies from ${fileName}")
+            return parser.getDependencies(file)
+        }
+        return []
     }
 }

--- a/src/main/groovy/com/ullink/packagesparser/NugetParser.groovy
+++ b/src/main/groovy/com/ullink/packagesparser/NugetParser.groovy
@@ -1,0 +1,6 @@
+package com.ullink.packagesparser
+
+interface NugetParser
+{
+    Collection getDependencies(File file)
+}

--- a/src/main/groovy/com/ullink/packagesparser/PackagesConfigParser.groovy
+++ b/src/main/groovy/com/ullink/packagesparser/PackagesConfigParser.groovy
@@ -10,9 +10,15 @@ class PackagesConfigParser implements NugetParser {
                 .each {
             packageElement ->
                 defaultDependencies.add({
-                    dependency(id: packageElement.@id, version: packageElement.@version)
+                    dependency(id: packageElement.@id, version: getVersion(packageElement))
                 })
         }
         return defaultDependencies;
+    }
+
+    String getVersion(Object element) {
+        if (element.@allowedVersions)
+            return element.@allowedVersions
+        return  element.@version
     }
 }

--- a/src/main/groovy/com/ullink/packagesparser/PackagesConfigParser.groovy
+++ b/src/main/groovy/com/ullink/packagesparser/PackagesConfigParser.groovy
@@ -1,0 +1,18 @@
+package com.ullink.packagesparser
+
+class PackagesConfigParser implements NugetParser {
+    @Override
+    Collection getDependencies(File file) {
+        def defaultDependencies = []
+        def packages = new XmlParser().parse(file)
+        packages.package
+                .findAll { !it.@developmentDependency.toString().toBoolean() }
+                .each {
+            packageElement ->
+                defaultDependencies.add({
+                    dependency(id: packageElement.@id, version: packageElement.@version)
+                })
+        }
+        return defaultDependencies;
+    }
+}

--- a/src/main/groovy/com/ullink/packagesparser/ProjectJsonParser.groovy
+++ b/src/main/groovy/com/ullink/packagesparser/ProjectJsonParser.groovy
@@ -7,9 +7,11 @@ class ProjectJsonParser implements NugetParser {
     Collection getDependencies(File file) {
         def dependencies = []
         def projectJson = new JsonSlurper().parse(file)
+        def projectJsonFile = new File(file.parentFile, "project.lock.json")
+        def projectLockJson = projectJsonFile.exists() ? new JsonSlurper().parse(projectJsonFile) : null
         projectJson.dependencies.each { packageElement ->
             if (!isBuildDependency(packageElement))
-                dependencies.add({ dependency(id: packageElement.key, version: getVersion(packageElement)) })
+                dependencies.add({ dependency(id: packageElement.key, version: getResolvedVersion(packageElement, projectLockJson)) })
         }
         return dependencies;
     }
@@ -20,5 +22,36 @@ class ProjectJsonParser implements NugetParser {
 
     String getVersion(Map.Entry entry) {
         return entry.value instanceof Map ? entry.value.version : entry.value
+    }
+
+    Boolean isBracket(String character) {
+        return character == '[' || character == '('|| character == ']' || character == ')'
+    }
+
+    String getResolvedVersion(Map.Entry entry, Object projectLockJson) {
+        def versionString = getVersion(entry)
+        def starIndex = versionString.indexOf('*')
+        // In case we don't have floating version, we return the version
+        // extracted from the json
+        if (starIndex == -1)
+            return versionString
+        // we need to take the currently resolved version from the lock file
+        // because the current project is built against this one so it needs this version
+        def dependencyFound = projectLockJson.libraries.find { it.key.startsWith(entry.key + '/') }
+        def versionResolved = dependencyFound.key.split('/')[1]
+        def commaIndex = versionString.indexOf(',')
+        // No range version so we return the build version
+        if (commaIndex == -1)
+        {
+            if (isBracket(versionString[0]))
+                return "${versionString[0]}${versionResolved}${versionString[-1]}"
+            return versionResolved
+        }
+        def versionSplit = versionString.split(',')
+        if (commaIndex > starIndex)
+        {
+            return "${versionString[0]}${versionResolved},${versionSplit[1]}"
+        }
+        return "${versionSplit[0]},${versionResolved}${versionString[-1]}"
     }
 }

--- a/src/main/groovy/com/ullink/packagesparser/ProjectJsonParser.groovy
+++ b/src/main/groovy/com/ullink/packagesparser/ProjectJsonParser.groovy
@@ -1,0 +1,24 @@
+package com.ullink.packagesparser
+
+import groovy.json.JsonSlurper
+
+class ProjectJsonParser implements NugetParser {
+    @Override
+    Collection getDependencies(File file) {
+        def dependencies = []
+        def projectJson = new JsonSlurper().parse(file)
+        projectJson.dependencies.each { packageElement ->
+            if (!isBuildDependency(packageElement))
+                dependencies.add({ dependency(id: packageElement.key, version: getVersion(packageElement)) })
+        }
+        return dependencies;
+    }
+
+    boolean isBuildDependency(Map.Entry entry) {
+        return entry.value instanceof Map && entry.value.type == "build"
+    }
+
+    String getVersion(Map.Entry entry) {
+        return entry.value instanceof Map ? entry.value.version : entry.value
+    }
+}

--- a/src/test/groovy/com/ullink/NuGetSpecTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetSpecTest.groovy
@@ -307,6 +307,53 @@ class NuGetSpecTest {
     }
 
     @Test
+    public void generateNuspec_defaultDependenciesFromPackageConfig_versionRanged() {
+        def project = newNugetProject()
+
+        project.nugetSpec {
+            nuspec {}
+        }
+
+        File.createTempDir().with { projectFolder ->
+            deleteOnExit()
+
+            def msbuildTask = new MSBuildTaskBuilder()
+                    .withAssemblyName('bar')
+                    .withProjectFile(new File(projectFolder.path, 'bar.csproj'))
+                    .build()
+            project.tasks.add(msbuildTask)
+
+            File packageConfig = new File(projectFolder, 'packages.config')
+            packageConfig.createNewFile()
+            packageConfig.write(
+                    '''<?xml version="1.0" encoding="utf-8"?>
+                        <packages>
+                            <package id="depBar" version="0.2.3.4" allowedVersions="(0.2.3.4,)" targetFramework="net35" />
+                            <package id="depFoo" version="100.5.6" allowedVersions="[100.5.6]" targetFramework="net35" />
+                            <package id="depBar2" version="1.2.3.4" developmentDependency="true" targetFramework="net35" />
+                            <package id="depFoo2" version="10.5.7" allowedVersions="[10.5.7, 10.6]" developmentDependency="false" targetFramework="net35" />
+                        </packages>'''
+            )
+
+            def expected =
+                    '''
+                    <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+                        <metadata>
+                            <id>foo</id>
+                            <version>2.1</version>
+                            <description>fooDescription</description>
+                            <dependencies>
+                                <dependency id="depBar" version="(0.2.3.4,)" />
+                                <dependency id="depFoo" version="[100.5.6]" />
+                                <dependency id="depFoo2" version="[10.5.7, 10.6]" />
+                            </dependencies>
+                        </metadata>
+                    </package>'''
+            assertXMLEqual(expected, project.tasks.nugetSpec.generateNuspec())
+        }
+    }
+
+    @Test
     public void generateNuspec_defaultDependenciesFromProjectJson() {
         def project = newNugetProject()
 
@@ -353,6 +400,73 @@ class NuGetSpecTest {
                                 <dependency id="depBar" version="0.2.3.4" />
                                 <dependency id="depFoo" version="100.5.6" />
                                 <dependency id="depFoo2" version="10.5.7" />
+                            </dependencies>
+                        </metadata>
+                    </package>'''
+            def nuspecGenerated = project.tasks.nugetSpec.generateNuspec()
+            assertXMLEqual(expected, nuspecGenerated)
+        }
+    }
+
+    @Test
+    public void generateNuspec_defaultDependenciesFromProjectJson_versionRanged() {
+        def project = newNugetProject()
+
+        project.nugetSpec {
+            nuspec {}
+        }
+
+        File.createTempDir().with { projectFolder ->
+            deleteOnExit()
+
+            def msbuildTask = new MSBuildTaskBuilder()
+                    .withAssemblyName('bar')
+                    .withProjectFile(new File(projectFolder.path, 'bar.csproj'))
+                    .build()
+            project.tasks.add(msbuildTask)
+
+            File projectJson = new File(projectFolder, 'project.json')
+            projectJson.createNewFile()
+            projectJson.write(
+                    '''{
+                          "dependencies": {
+                            "depBar": "[0.2.3.4]",
+                            "depFoo": "[100.5.*, 100.6)",
+                            "depBar2": {"version": "1.2.3.4", "type":"build"},
+                            "depFoo2": {"version": "[10.5.*]", "type":"default"}
+                          },
+                          "frameworks": {
+                            "net35": {}
+                          },
+                          "runtimes": {
+                            "win": {}
+                          }
+                        }'''
+            )
+            File projectLockJson = new File(projectFolder, 'project.lock.json')
+            projectLockJson.createNewFile()
+            projectLockJson.write(
+                    '''{
+                          "libraries": {
+                            "depFoo/100.5.2": {
+                            },
+                            "depFoo2/10.5.7": {
+                            }
+                          }
+                        }'''
+            )
+
+            def expected =
+                    '''
+                    <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+                        <metadata>
+                            <id>foo</id>
+                            <version>2.1</version>
+                            <description>fooDescription</description>
+                            <dependencies>
+                                <dependency id="depBar" version="[0.2.3.4]" />
+                                <dependency id="depFoo" version="[100.5.2, 100.6)" />
+                                <dependency id="depFoo2" version="[10.5.7]" />
                             </dependencies>
                         </metadata>
                     </package>'''


### PR DESCRIPTION
The plugin used to only managed the packages.config.
These two commits enable the project.json as well.

The first is here to create the nuspec from the project.json and the second manage the range (It also manage the '*' )

Nuget range are detailed here: https://docs.nuget.org/create/versioning