### PR TITLE
Added nugetUrl option to allow the nuget.exe download url to be overr…

### DIFF
--- a/src/main/groovy/com/ullink/BaseNuGet.groovy
+++ b/src/main/groovy/com/ullink/BaseNuGet.groovy
@@ -38,13 +38,9 @@ public class BaseNuGet extends Exec {
                 nugetUrl = project.extensions.nuget.nugetUrl
             } else {            
                 def version = project.extensions.nuget.version
-                def exeName = 'NuGet.exe'
-                if(version != "latest") {
-                    exeName = version < '3.4.4' ? 'nuget.exe' : exeName
-                    version = "v${version}"
-                }
-                nugetUrl = "https://dist.nuget.org/win-x86-commandline/${version}/${exeName}"
-            }
+                def exeName = version < '3.4.4' ? 'nuget.exe' : 'NuGet.exe'
+                nugetUrl = "https://dist.nuget.org/win-x86-commandline/v${version}/${exeName}"
+            } 
             project.logger.debug "Downloading NuGet from $nugetUrl ..."
             new URL(nugetUrl).withInputStream { i -> localNuget.withOutputStream{ it << i } }
         }

--- a/src/main/groovy/com/ullink/BaseNuGet.groovy
+++ b/src/main/groovy/com/ullink/BaseNuGet.groovy
@@ -33,8 +33,18 @@ public class BaseNuGet extends Exec {
         if (!localNuget.exists()) {
             if (!folder.isDirectory())
                 folder.mkdirs()
-            def exeName = project.extensions.nuget.version < '3.4.4' ? 'nuget.exe' : 'NuGet.exe'
-            def nugetUrl = "https://dist.nuget.org/win-x86-commandline/v${project.extensions.nuget.version}/${exeName}"
+            def nugetUrl = ""
+            if (project.extensions.nuget.nugetUrl != null) {
+                nugetUrl = project.extensions.nuget.nugetUrl
+            } else {            
+                def version = project.extensions.nuget.version
+                def exeName = 'NuGet.exe'
+                if(version != "latest") {
+                    exeName = version < '3.4.4' ? 'nuget.exe' : exeName
+                    version = "v${version}"
+                }
+                nugetUrl = "https://dist.nuget.org/win-x86-commandline/${version}/${exeName}"
+            }
             project.logger.debug "Downloading NuGet from $nugetUrl ..."
             new URL(nugetUrl).withInputStream { i -> localNuget.withOutputStream{ it << i } }
         }

--- a/src/main/groovy/com/ullink/NuGetExtension.groovy
+++ b/src/main/groovy/com/ullink/NuGetExtension.groovy
@@ -2,4 +2,5 @@ package com.ullink
 
 class NuGetExtension {
     String version = '4.4.0'
+    String nugetUrl = null
 }


### PR DESCRIPTION
Fix for issue #43 - Added nugetUrl option to allow the nuget.exe download url to be overridden.  Also made it so the 'v' is not added into the url if the version is 'latest'
