### PR TITLE
Avoid NPE when parseProject=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gradle-nuget-plugin changelog
 
+## 2.15
+### Fixed
+* In nugetspec, do not access to mainProject when parseProject=false
+
 ## 2.13
 ### Changed
 * Default NuGet version used is 3.3.0.

--- a/src/test/groovy/com/ullink/MSBuildTaskBuilder.groovy
+++ b/src/test/groovy/com/ullink/MSBuildTaskBuilder.groovy
@@ -16,6 +16,7 @@ class MSBuildTaskBuilder {
         mainProject.metaClass.getProperties = { mainProjectProperties }
         mainProject.metaClass.getDotnetArtifacts = { artifacts }
         msbuildTask.metaClass.getMainProject = { mainProject }
+        msbuildTask.metaClass.parseProject = true
     }
 
     public Task build() {

--- a/src/test/groovy/com/ullink/NuGetSpecTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetSpecTest.groovy
@@ -233,6 +233,27 @@ class NuGetSpecTest {
     }
 
     @Test
+    public void generateNuspec_noDefaultFilesFromCsprojIfParseProjectIsFalse() {
+        def project = newNugetWithMsbuildProject()
+        project.tasks.msbuild.metaClass.parseProject = false
+
+        project.nugetSpec {
+            nuspec { }
+        }
+
+        def expected =
+                '''
+        <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+            <metadata>
+                <id>foo</id>
+                <version>2.1</version>
+                <description>fooDescription</description>
+            </metadata>
+        </package>'''.replace('\\', File.separator)
+        assertXMLEqual (expected, project.tasks.nugetSpec.generateNuspec())
+    }
+
+    @Test
     public void generateNuspec_withoutDefaultFilesAsTheyAreAlreadyProvided() {
         def project = newNugetWithMsbuildProject()
 


### PR DESCRIPTION
msbuild task has a boolean called parseProject
when set to false, the task does not parse the
project file. As a consequence the mainProject
property is never set
the nugetspec was using the property mainPRoject
now, when parsing is disabled, the property is
not accessed anymore