### PR TITLE
Nuspec XmlSlurper should not be namespace aware

### DIFF
--- a/src/main/groovy/com/ullink/NuGetPack.groovy
+++ b/src/main/groovy/com/ullink/NuGetPack.groovy
@@ -1,13 +1,8 @@
 package com.ullink
 
-import groovy.util.XmlSlurper
 import groovy.util.slurpersupport.GPathResult
-import groovy.xml.XmlUtil
 import org.apache.commons.io.FilenameUtils
 import org.gradle.api.plugins.BasePlugin
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputFile
-import org.gradle.api.Task
 
 class NuGetPack extends BaseNuGet {
 
@@ -102,7 +97,7 @@ class NuGetPack extends BaseNuGet {
     GPathResult getNuspec() {
         def nuspecFile = getNuspecFile()
         if (nuspecFile?.exists()) {
-            return new XmlSlurper().parse(project.file(nuspecFile))
+            return new XmlSlurper(false, false).parse(project.file(nuspecFile))
         }
         if (dependentNuGetSpec) {
             def generatedNuspec = dependentNuGetSpec.generateNuspec()


### PR DESCRIPTION
This unifies the behavior to be consistent with the
dependent nuspec's XmlSlurper

This prevents the generation of `tag0` namespace for the nodes.