### PR TITLE
Allow overriding package version from script

### DIFF
--- a/src/main/groovy/com/ullink/NuGetPack.groovy
+++ b/src/main/groovy/com/ullink/NuGetPack.groovy
@@ -12,6 +12,7 @@ class NuGetPack extends BaseNuGet {
 
     def destinationDir = project.convention.plugins.base.distsDir
     def basePath
+    def packageVersion
     def exclude
     def generateSymbols = false
     def tool = false
@@ -52,7 +53,7 @@ class NuGetPack extends BaseNuGet {
 
         if (basePath) args '-BasePath', basePath
 
-        def version = spec?.metadata?.version ?: project.version
+        def version = getFinalPackageVersion(spec)
         if (version) args '-Version', version
 
         if (exclude) args '-Exclude', exclude
@@ -121,9 +122,13 @@ class NuGetPack extends BaseNuGet {
 
     File getPackageFile() {
         def spec = getNuspec()
-        def version = spec?.metadata?.version ?: project.version
+        def version = getFinalPackageVersion(spec)
         def id = spec?.metadata?.id?.toString() ?: getIdFromMsbuildTask()
         new File(getDestinationDir(), id + '.' + version + '.nupkg')
+    }
+
+    private String getFinalPackageVersion(spec) {
+        return packageVersion ?: spec?.metadata?.version ?: project.version
     }
 
     String getIdFromMsbuildTask() {

--- a/src/test/groovy/com/ullink/NuGetPluginTest.groovy
+++ b/src/test/groovy/com/ullink/NuGetPluginTest.groovy
@@ -55,4 +55,38 @@ class NuGetPluginTest {
         project.tasks.nugetPack.execute()
         assertTrue(project.tasks.nugetPack.packageFile.exists())
     }
+
+    @Test
+    public void nugetPackSpecifyVersion() {
+
+        project.tasks.clean.execute()
+
+        File nuspec = new File(project.tasks.nugetPack.temporaryDir, 'bar.nuspec')
+        nuspec.text = '''<?xml version='1.0'?>
+<package xmlns='http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd'>
+  <metadata>
+    <id>bar</id>
+    <authors>Nobody</authors>
+    <version>1.2.3</version>
+    <description>fooDescription</description>
+  </metadata>
+  <files>
+    <file src='bar.txt' />
+  </files>
+</package>'''
+
+        File fooFile = new File(project.tasks.nugetPack.temporaryDir, 'bar.txt')
+        fooFile.text = "Bar"
+
+        project.nugetPack {
+            basePath = project.tasks.nugetPack.temporaryDir
+            nuspecFile = nuspec
+            packageVersion = "100.200.300"
+        }
+
+        project.tasks.nugetPack.execute()
+        def packageFile = project.tasks.nugetPack.packageFile
+        assertEquals("bar.100.200.300.nupkg", packageFile.name)
+        assertTrue(packageFile.exists())
+    }
 }


### PR DESCRIPTION
Hello. Hope you don't mind a surprise PR!

I hit a problem with the `nugetPack` task because I want to push the version of the package from my build script (via CI, etc). I've added a `packageVersion` property to `nugetPack` which will override the version in the nuspec file (mine is `$version$`, which would also cause problems!) and will fall back to the version in the nuspec or the project version, as before.